### PR TITLE
added remoteip to logging

### DIFF
--- a/application/controllers/LogController.php
+++ b/application/controllers/LogController.php
@@ -36,6 +36,7 @@ class LogController extends Controller
             'fields'    => '/(?<!.)' // ^ can't handle multilines, don't ask *me* why this works
                 . '(?<datetime>[0-9]{4}(?:-[0-9]{2}){2}'                    // date
                 . 'T[0-9]{2}(?::[0-9]{2}){2}(?:[\+\-][0-9]{2}:[0-9]{2})?)'  // time
+                . ' - (?<remoteip>.+)'                                      // remoteip
                 . ' - (?<identity>.+)'                                      // identity
                 . ' - (?<type>.+)'                                          // type
                 . ' - (?<message>.+)'                                       // message

--- a/application/views/scripts/log/index.phtml
+++ b/application/views/scripts/log/index.phtml
@@ -19,6 +19,9 @@
                     <br>
                     <?= $this->escape($value->type) ?>
                 </td>
+                <td style="width: 6em; text-align: center">
+                    <?= $this->escape($value->remoteip) ?>
+                </td>
                 <td style="width: 12em; text-align: center">
                     <?= $this->escape($value->identity) ?>
                 </td>

--- a/library/Audit/ProvidedHook/AuditLog.php
+++ b/library/Audit/ProvidedHook/AuditLog.php
@@ -14,8 +14,9 @@ class AuditLog extends AuditHook
     {
         $logConfig = Config::module('audit')->getSection('log');
         if ($logConfig->type === 'file') {
+            $remoteip = (!empty($_SERVER['HTTP_X_FORWARDED_FOR'])) ? $_SERVER['HTTP_X_FORWARDED_FOR'] : $_SERVER['REMOTE_ADDR'];
             $file = new File($logConfig->get('path', '/var/log/icingaweb2/audit.log'), 'a');
-            $file->fwrite(date('c', $time) . ' - ' . $identity . ' - ' . $type . ' - ' . $message . PHP_EOL);
+            $file->fwrite(date('c', $time) . ' - ' . $remoteip . ' - ' . $identity . ' - ' . $type . ' - ' . $message . PHP_EOL);
             $file->fflush();
         } elseif ($logConfig->type === 'syslog') {
             openlog(

--- a/library/Audit/ProvidedHook/AuditStream.php
+++ b/library/Audit/ProvidedHook/AuditStream.php
@@ -16,7 +16,8 @@ class AuditStream extends AuditHook
             'activity_time' => $time,
             'activity'      => $type,
             'message'       => $message,
-            'identity'      => $identity
+            'identity'      => $identity,
+            'remoteip'      => $remoteip
         ];
         if (! empty($data)) {
             $activityData['data'] = $data;


### PR DESCRIPTION
I have added the Remote-IP to the Audit-Log. Useful for e.g. _fail2ban_.
Uses `HTTP_X_FORWARDED_FOR`-Header if present, if not uses `REMOTE_ADDR`