### PR TITLE
Support PHP 8.5

### DIFF
--- a/library/Audit/ProvidedHook/AuditLog.php
+++ b/library/Audit/ProvidedHook/AuditLog.php
@@ -11,7 +11,7 @@ use Icinga\Util\File;
 
 class AuditLog extends AuditHook
 {
-    public function logMessage($time, $identity, $type, $message, array $data = null): void
+    public function logMessage($time, $identity, $type, $message, ?array $data = null): void
     {
         $logConfig = Config::module('audit')->getSection('log');
         if ($logConfig->type === 'file') {

--- a/library/Audit/ProvidedHook/AuditStream.php
+++ b/library/Audit/ProvidedHook/AuditStream.php
@@ -11,7 +11,7 @@ use Icinga\Util\File;
 
 class AuditStream extends AuditHook
 {
-    public function logMessage($time, $identity, $type, $message, array $data = null): void
+    public function logMessage($time, $identity, $type, $message, ?array $data = null): void
     {
         $activityData = [
             'activity_time' => $time,


### PR DESCRIPTION
resolves #31

## Changes made:
### PHP 8.4:
- [Function parameters that are null by default must be declared nullable](https://www.php.net/manual/en/migration84.deprecated.php#migration84.deprecated.core).


No changes are required for PHP8.5 support.